### PR TITLE
Stop 'cleaning' HTML

### DIFF
--- a/app/assets/javascripts/rails_admin/custom/ui.coffee
+++ b/app/assets/javascripts/rails_admin/custom/ui.coffee
@@ -11,6 +11,7 @@ class TinyMCEActivator
       selector: @_getSelector(),
       plugins: "image link table media print charmap preview code"
       convert_urls: false
+      verify_html: false
 
   _ensureSelectorClass: ->
     if @textArea.getAttribute('tiny-id') is null


### PR DESCRIPTION
TinyMCE strips various tags and attributes, such as onclick, by default. This
will disable the feature, you can add some JavaScript into your CMS content.